### PR TITLE
Updating flask version to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.1.0
+Flask==2.0.0
 stripe==2.56.0
 python-dotenv==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==1.1.1
+Flask==2.1.0
 stripe==2.56.0
 python-dotenv==0.19.0


### PR DESCRIPTION
I ran into a weird issue when running the project around the escape module for jinja2. From my reading it sounds like jinja2 is no longer compatible for Flask 1.x.x? It would be great to confirm this with you as I might have misunderstood the source of the error!

It looks like some of these other libraries may also not play nicely with Flask 1.x.x anymore unless frozen to a previous version:
- jinja2
- itsdangerous
- werkzeug

After doing some digging I found two ways to remediate, please let me know if either of these sound like a good plan!

Solution 1:
Update Flask version to second major version - 2.0.0 will resolve the error around jinja2 and escape module:
`ImportError: cannot import name 'escape' from 'jinja2'`

Context on error: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2

Solution 2:
Maintain Flask version 1.1.1 but lock some of these libraries to prior versions:
- Jinja2==3.0.3
- itsdangerous==2.0.1
- werkzeug==2.0.2

Discussion on error: https://github.com/pallets/flask/issues/4494

I am not too familiar with Python ecosystem so please let me know if I have assumed anything incorrectly! And thank you for taking a look at this!